### PR TITLE
Fix Ninjemail import path

### DIFF
--- a/nmCore.py
+++ b/nmCore.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 
 # Try to import the actual ninjemail library
 try:
-    from ninjemail import Ninjemail as NinjemailLib
+    from ninjemail.ninjemail import Ninjemail as NinjemailLib
     NINJEMAIL_AVAILABLE = True
 except ImportError:
     NINJEMAIL_AVAILABLE = False


### PR DESCRIPTION
## Summary
- fix nmCore import to target nested ninjemail module and keep simulation fallback

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68be2cf7ef9883209061c1c26b0ba440