### PR TITLE
Add top-level ninjemail package initializer

### DIFF
--- a/ninjemail/__init__.py
+++ b/ninjemail/__init__.py
@@ -1,0 +1,3 @@
+from .ninjemail import Ninjemail
+
+__all__ = ["Ninjemail"]


### PR DESCRIPTION
## Summary
- Re-export the `Ninjemail` class at the top-level `ninjemail` package to allow straightforward imports

## Testing
- `python -m pytest` *(fails: 12 failed, 73 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68be2dd0c5508320944fd9c6324d15a9