### PR TITLE
Fix module import to nmCore

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -7,7 +7,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox, scrolledtext, filedialog
 import threading
 from datetime import datetime
-import ninjemail as nm  # Import our ninjemail module
+import nmCore as nm  # Import our ninjemail module
 
 
 class NinjemailGUI:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ Can run in CLI mode or launch the GUI
 
 import sys
 import argparse
-import ninjemail as nm
+import nmCore as nm
 from gui import run_gui
 
 

--- a/ninjemail/__init__.py
+++ b/ninjemail/__init__.py
@@ -1,0 +1,3 @@
+from .ninjemail import Ninjemail
+
+__all__ = ["Ninjemail"]

--- a/nmCore.py
+++ b/nmCore.py
@@ -8,22 +8,17 @@ import string
 from datetime import datetime, timedelta
 import json
 import os
+import warnings
 from typing import List, Optional
 
 # Try to import the actual ninjemail library
 try:
-    from ninjemail import Ninjemail as NinjemailLib
-
+    # Import from the nested package bundled with this repository
+    from ninjemail.ninjemail import Ninjemail as NinjemailLib
     NINJEMAIL_AVAILABLE = True
 except ImportError:
-    print("Warning: ninjemail library not found. Install with: pip install ninjemail")
     NINJEMAIL_AVAILABLE = False
     NinjemailLib = None
-
-import random
-import string
-from datetime import datetime, timedelta
-from typing import List, Optional
 
 
 class DataGenerator:
@@ -218,6 +213,11 @@ class AccountCreator:
 
         # If ninjemail library is not available, simulate account creation
         if not NINJEMAIL_AVAILABLE:
+            warnings.warn(
+                "ninjemail library not found; running in simulation mode. "
+                "Install with 'pip install ninjemail' for real account creation.",
+                RuntimeWarning,
+            )
             print(f"[SIMULATION] Would create {provider} account:")
             print(f"  Username: {username}")
             print(f"  Password: {password}")


### PR DESCRIPTION
## Summary
- Use the local ninjemail package by importing `Ninjemail` from its nested module
- Re-export `Ninjemail` at the package root so `import ninjemail` works

## Testing
- `python -m py_compile main.py gui.py nmCore.py`
- `python main.py --generate-only`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distutils' from `undetected_chromedriver`)*

------
https://chatgpt.com/codex/tasks/task_e_68be18d3db7c8320b962a4a585d7ce16